### PR TITLE
[minor] "custom" module

### DIFF
--- a/doc/modules/custom.rst
+++ b/doc/modules/custom.rst
@@ -1,0 +1,52 @@
+.. _custom:
+
+.. currentmodule:: boto3_refresh_session.custom
+
+boto3_refresh_session.custom
+============================
+
+Implements a custom credential refresh strategy for use with
+:class:`boto3_refresh_session.session.RefreshableSession`.
+
+This module defines the :class:`CustomRefreshableSession` class, which retrieves
+temporary credentials using a user provided custom credential method and automatically
+refreshes those credentials in the background.
+
+This module is useful for users with highly sophisticated, novel, or idiosyncratic
+authentication flows not included in this library. This module is AWS service agnostic.
+Meaning: this module is extremely flexible.
+
+.. versionadded:: 1.2.4
+
+Examples
+--------
+Write (or import) the method for obtaining temporary AWS security credentials.
+
+>>> def your_custom_credential_getter(your_param, another_param):
+>>>     ...
+>>>     return {
+>>>         'access_key': ...,
+>>>         'secret_key': ...,
+>>>         'token': ...,
+>>>         'expiry_time': ...,
+>>>     }
+
+Pass that method to ``RefreshableSession``.
+
+>>> sess = RefreshableSession(
+>>>     method='custom',
+>>>     custom_credentials_method=your_custom_credential_getter,
+>>>     custom_credentials_methods_args=...,
+>>> )
+
+.. seealso::
+   :class:`boto3_refresh_session.session.RefreshableSession`
+
+Custom
+------ 
+
+.. autosummary::
+   :toctree: generated/
+   :nosignatures:
+
+   CustomRefreshableSession

--- a/doc/modules/custom.rst
+++ b/doc/modules/custom.rst
@@ -16,7 +16,7 @@ This module is useful for users with highly sophisticated, novel, or idiosyncrat
 authentication flows not included in this library. This module is AWS service agnostic.
 Meaning: this module is extremely flexible.
 
-.. versionadded:: 1.2.4
+.. versionadded:: 1.3.0
 
 Examples
 --------

--- a/doc/modules/generated/boto3_refresh_session.custom.CustomRefreshableSession.rst
+++ b/doc/modules/generated/boto3_refresh_session.custom.CustomRefreshableSession.rst
@@ -1,0 +1,8 @@
+boto3\_refresh\_session.custom.CustomRefreshableSession
+=======================================================
+
+.. currentmodule:: boto3_refresh_session.custom
+
+.. autoclass:: CustomRefreshableSession
+   :exclude-members: __init__, __new__
+   :inherited-members:

--- a/doc/modules/index.rst
+++ b/doc/modules/index.rst
@@ -16,6 +16,7 @@ boto3-refresh-session includes multiple modules, grouped into two categories:
 
    exceptions
    session
+   custom
    sts
    ecs
 
@@ -35,15 +36,18 @@ The :class:`boto3_refresh_session.session.RefreshableSession` class provides a u
 Refresh strategies
 ------------------
 
-boto3-refresh-session is designed to grow.
-In addition to the default STS strategy, support for additional credential sources like AWS IoT, SSO, and others will be added in future releases.
+boto3-refresh-session supports multiple AWS services.
+There is also a highly flexible module named "custom" for users with highly sophisticated, novel, or idiosyncratic authentication flows.
 
 .. tip::
    
-   It is recommended to use :class:`boto3_refresh_session.session.RefreshableSession` instead of initializing the below classes. 
+   It is recommended to use :class:`boto3_refresh_session.session.RefreshableSession` instead of initializing the below classes.
+   Refer to the below documentation to understand what sort of parameters each refresh strategy requires and what sort of methods
+   are available.
 
 Each strategy supported by boto3-refresh-session is encapsulated in its own module below.
 
+- :ref:`custom` - Refresh strategy using a custom credential refresh strategy
 - :ref:`sts` — Refresh strategy using :class:`STS.Client`
 - :ref:`ecs` - Refresh strategy using AWS ECS container metadata
 


### PR DESCRIPTION
## All submissions

* [x] Did you include the version part parameter, i.e. [major | minor | patch], to the beginning of the pull request title so that the version is bumped correctly? 
    * Example pull request title: '[minor] Added a new parameter to the `RefreshableSession` object.'
    * Note: the version part parameter is only required for major and minor updates. Patches may exclude the part parameter from the pull request title, as the default is 'patch'.
* [x] Did you verify that your changes pass pre-commit checks before opening this pull request?
    * The pre-commit checks are identical to required status checks for pull requests in this repository. Know that suppressing pre-commit checks via the `--no-verify` | `-nv` arguments will not help you avoid the status checks!
    * To ensure that pre-commit checks work on your branch before running `git commit`, run `pre-commit install` and `pre-commit install-hooks` beforehand. 
* [x] Have you checked that your changes don't relate to other open pull requests?

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

## New feature submissions

* [x] Does your new feature include documentation? If not, why not?
    * [x] Does that documentation match the numpydoc guidelines?
    * [x] Did you locally test your documentation changes using `sphinx-build doc doc/_build` from the root directory?
* [ ] Did you write unit tests for the new feature? If not, why not?
    * [ ] Did the unit tests pass?
    * [ ] Did you know that locally running unit tests requires an AWS account? 
        * You must create a ROLE_ARN environment variable on your machine using `export ROLE_ARN=<your role arn here>`.

## Submission details

The following PR contains a new module called "custom". It allows users with highly sophisticated, novel, or idiosyncratic authentication flows to provide their own custom `_get_credentials` method. Generally speaking, this module will be mostly useful for enterprise users. Like all other service modules, the custom module should be used by calling the `RefreshableSession` object and specifying `method="custom"` when initializing `RefreshableSession`.