### PR TITLE
Deprecated initialize method for __post_init__ method.

### DIFF
--- a/boto3_refresh_session/__init__.py
+++ b/boto3_refresh_session/__init__.py
@@ -1,3 +1,6 @@
+from .methods.custom import CustomRefreshableSession
+from .methods.ecs import ECSRefreshableSession
+from .methods.sts import STSRefreshableSession
 from .session import RefreshableSession
 
 __all__ = ["RefreshableSession"]

--- a/boto3_refresh_session/methods/custom.py
+++ b/boto3_refresh_session/methods/custom.py
@@ -6,7 +6,7 @@ from typing import Any, Callable
 
 from ..exceptions import BRSError
 from ..session import BaseRefreshableSession
-from ..utils import TemporaryCredentials
+from ..utils import RefreshMethod, TemporaryCredentials
 
 
 class CustomRefreshableSession(BaseRefreshableSession, registry_key="custom"):
@@ -66,6 +66,8 @@ class CustomRefreshableSession(BaseRefreshableSession, registry_key="custom"):
         defer_refresh: bool | None = None,
         **kwargs,
     ):
+        self.defer_refresh = defer_refresh is not False
+        self.refresh_method: RefreshMethod = "custom"
         super().__init__(**kwargs)
 
         self._custom_get_credentials = custom_credentials_method
@@ -73,12 +75,6 @@ class CustomRefreshableSession(BaseRefreshableSession, registry_key="custom"):
             custom_credentials_method_args
             if custom_credentials_method_args is not None
             else {}
-        )
-
-        self.initialize(
-            credentials_method=self._get_credentials,
-            defer_refresh=defer_refresh is not False,
-            refresh_method="custom",
         )
 
     def _get_credentials(self) -> TemporaryCredentials:

--- a/boto3_refresh_session/methods/ecs.py
+++ b/boto3_refresh_session/methods/ecs.py
@@ -8,7 +8,7 @@ import requests
 
 from ..exceptions import BRSError
 from ..session import BaseRefreshableSession
-from ..utils import TemporaryCredentials
+from ..utils import RefreshMethod, TemporaryCredentials
 
 _ECS_CREDENTIALS_RELATIVE_URI = "AWS_CONTAINER_CREDENTIALS_RELATIVE_URI"
 _ECS_CREDENTIALS_FULL_URI = "AWS_CONTAINER_CREDENTIALS_FULL_URI"
@@ -35,17 +35,13 @@ class ECSRefreshableSession(BaseRefreshableSession, registry_key="ecs"):
     """
 
     def __init__(self, defer_refresh: bool | None = None, **kwargs):
-        super().__init__(**kwargs)
+        self.defer_refresh: bool = defer_refresh is not False
+        self.refresh_method: RefreshMethod = "ecs-container-metadata"
+        super().__init__(**kwargs)  # mounting refreshable credentials
 
         self._endpoint = self._resolve_endpoint()
         self._headers = self._build_headers()
         self._http = self._init_http_session()
-
-        self.initialize(
-            credentials_method=self._get_credentials,
-            defer_refresh=defer_refresh is not False,
-            refresh_method="ecs-container-metadata",
-        )
 
     def _resolve_endpoint(self) -> str:
         uri = os.environ.get(_ECS_CREDENTIALS_FULL_URI) or os.environ.get(

--- a/boto3_refresh_session/utils.py
+++ b/boto3_refresh_session/utils.py
@@ -115,22 +115,16 @@ class BRSSession(Session):
     def __init__(self, **kwargs):
         super().__init__(**kwargs)
 
-    def initialize(
-        self,
-        credentials_method: Callable,
-        defer_refresh: bool,
-        refresh_method: RefreshMethod,
-    ):
-        # determining how exactly to refresh expired temporary credentials
-        if not defer_refresh:
+    def __post_init__(self):
+        if not self.defer_refresh:
             self._credentials = RefreshableCredentials.create_from_metadata(
-                metadata=credentials_method(),
-                refresh_using=credentials_method,
-                method=refresh_method,
+                metadata=self._get_credentials(),
+                refresh_using=self._get_credentials,
+                method=self.refresh_method,
             )
         else:
             self._credentials = DeferredRefreshableCredentials(
-                refresh_using=credentials_method, method=refresh_method
+                refresh_using=self._get_credentials, method=self.refresh_method
             )
 
     def refreshable_credentials(self) -> RefreshableTemporaryCredentials:


### PR DESCRIPTION
The following PR is:

- A bug fix for [this issue](https://github.com/michaelthomasletts/boto3-refresh-session/issues/70)
- Supplants the `initialize` method with `__post_init__`

For more information about the bug, please check the above issue.

Apropos deprecation of `initialize` in favor of `__post_init__`, this change removes the need to call the `initialize` method when creating new AWS service classes. 