### PR TITLE
Typing hints for methods.custom submodule.

### DIFF
--- a/boto3_refresh_session/methods/custom.py
+++ b/boto3_refresh_session/methods/custom.py
@@ -6,7 +6,12 @@ from typing import Any, Callable
 
 from ..exceptions import BRSError, BRSWarning
 from ..session import BaseRefreshableSession
-from ..utils import TemporaryCredentials, refreshable_session
+from ..utils import (
+    CustomCredentialsMethod,
+    CustomCredentialsMethodArgs,
+    TemporaryCredentials,
+    refreshable_session,
+)
 
 
 @refreshable_session
@@ -18,11 +23,11 @@ class CustomRefreshableSession(BaseRefreshableSession, registry_key="custom"):
 
     Parameters
     ----------
-    custom_credentials_method: Callable
+    custom_credentials_method: CustomCredentialsMethod
         Required. Accepts a callable object that returns temporary AWS
         security credentials. That object must return a dictionary containing
         'access_key', 'secret_key', 'token', and 'expiry_time' when called.
-    custom_credentials_method_args : dict[str, Any], optional
+    custom_credentials_method_args : CustomCredentialsMethodArgs, optional
         Optional keyword arguments for the function passed to the
         ``custom_credentials_method`` parameter.
     defer_refresh : bool, optional
@@ -62,8 +67,10 @@ class CustomRefreshableSession(BaseRefreshableSession, registry_key="custom"):
 
     def __init__(
         self,
-        custom_credentials_method: Callable,
-        custom_credentials_method_args: dict[str, Any] | None = None,
+        custom_credentials_method: CustomCredentialsMethod,
+        custom_credentials_method_args: (
+            CustomCredentialsMethodArgs | None
+        ) = None,
         **kwargs,
     ):
         if "refresh_method" in kwargs:
@@ -75,8 +82,10 @@ class CustomRefreshableSession(BaseRefreshableSession, registry_key="custom"):
 
         # initializing BRSSession
         super().__init__(refresh_method="custom", **kwargs)
-        self._custom_get_credentials = custom_credentials_method
-        self._custom_get_credentials_args = (
+        self._custom_get_credentials: CustomCredentialsMethod = (
+            custom_credentials_method
+        )
+        self._custom_get_credentials_args: CustomCredentialsMethodArgs = (
             custom_credentials_method_args
             if custom_credentials_method_args is not None
             else {}

--- a/boto3_refresh_session/utils.py
+++ b/boto3_refresh_session/utils.py
@@ -136,7 +136,7 @@ class _CustomCredentialsMethod(Protocol):
 #: Type alias for custom credential retrieval methods.
 CustomCredentialsMethod: TypeAlias = _CustomCredentialsMethod
 
-#: Type alias for keyword arguments to pass to custom credential retrieval methods.
+#: Type alias for custom credential method arguments.
 CustomCredentialsMethodArgs: TypeAlias = Mapping[str, Any]
 
 

--- a/boto3_refresh_session/utils.py
+++ b/boto3_refresh_session/utils.py
@@ -10,6 +10,9 @@ from typing import (
     Generic,
     List,
     Literal,
+    Mapping,
+    Protocol,
+    TypeAlias,
     TypedDict,
     TypeVar,
     cast,
@@ -124,6 +127,17 @@ class TemporaryCredentials(TypedDict):
     secret_key: str
     token: str
     expiry_time: datetime | str
+
+
+class _CustomCredentialsMethod(Protocol):
+    def __call__(self, **kwargs: Any) -> TemporaryCredentials: ...
+
+
+#: Type alias for custom credential retrieval methods.
+CustomCredentialsMethod: TypeAlias = _CustomCredentialsMethod
+
+#: Type alias for keyword arguments to pass to custom credential retrieval methods.
+CustomCredentialsMethodArgs: TypeAlias = Mapping[str, Any]
 
 
 class RefreshableTemporaryCredentials(TypedDict):


### PR DESCRIPTION
The following PR includes typing hints for the `methods.custom` submodule.