### PR TITLE
[patch] Adding "awsiot" to importlib check for extra safety

### DIFF
--- a/boto3_refresh_session/__init__.py
+++ b/boto3_refresh_session/__init__.py
@@ -16,7 +16,10 @@ from .utils.cache import *
 from .utils.config import *
 
 # checking if iot extra is installed
-if importlib.util.find_spec("awscrt") is not None:
+if (
+    importlib.util.find_spec("awscrt") is not None
+    and importlib.util.find_spec("awsiot") is not None
+):
     from .methods.iot import *
 
 __all__.extend(cache.__all__)

--- a/boto3_refresh_session/methods/__init__.py
+++ b/boto3_refresh_session/methods/__init__.py
@@ -14,7 +14,10 @@ __all__.extend(custom.__all__)
 __all__.extend(sts.__all__)
 
 # checking if iot extra is installed
-if importlib.util.find_spec("awscrt") is not None:
+if (
+    importlib.util.find_spec("awscrt") is not None
+    and importlib.util.find_spec("awsiot") is not None
+):
     from . import iot
     from .iot import *
 

--- a/boto3_refresh_session/methods/iot/__init__.py
+++ b/boto3_refresh_session/methods/iot/__init__.py
@@ -10,7 +10,10 @@ __all__ = []
 import importlib.util
 
 # checking if iot extra is installed
-if importlib.util.find_spec("awscrt") is not None:
+if (
+    importlib.util.find_spec("awscrt") is not None
+    and importlib.util.find_spec("awsiot") is not None
+):
     from . import core
     from .core import IoTRefreshableSession
     from .x509 import IOTX509RefreshableSession

--- a/boto3_refresh_session/utils/internal.py
+++ b/boto3_refresh_session/utils/internal.py
@@ -42,6 +42,7 @@ __all__ = [
     "refreshable_session",
 ]
 
+import importlib.util
 from abc import ABC, abstractmethod
 from functools import wraps
 from typing import Any, Callable, ClassVar, Generic, TypeVar, cast
@@ -360,13 +361,14 @@ class BaseRefreshableSession(
 
 
 # checking if iot extra is installed
-try:
+if (
+    importlib.util.find_spec("awscrt") is not None
+    and importlib.util.find_spec("awsiot") is not None
+):
     from awscrt.http import HttpHeaders
 
     from .typing import IoTAuthenticationMethod
-except ModuleNotFoundError:
-    ...
-else:
+
     __all__ += ["AWSCRTResponse", "BaseIoTRefreshableSession"]
 
     class BaseIoTRefreshableSession(

--- a/boto3_refresh_session/utils/typing.py
+++ b/boto3_refresh_session/utils/typing.py
@@ -19,6 +19,7 @@ __all__ = [
     "TemporaryCredentials",
 ]
 
+import importlib.util
 from datetime import datetime
 from typing import (
     Any,
@@ -37,14 +38,10 @@ except ImportError:
     from typing_extensions import NotRequired
 
 # checking if iot extra is installed
-try:
-    import awscrt  # typing: ignore[import] # noqa: F401
-except ModuleNotFoundError:
-    _IOT_EXTRA_INSTALLED = False
-else:
-    _IOT_EXTRA_INSTALLED = True
-
-if _IOT_EXTRA_INSTALLED:
+if _IOT_EXTRA_INSTALLED := (
+    importlib.util.find_spec("awscrt") is not None
+    and importlib.util.find_spec("awsiot") is not None
+):
     __all__ += [
         "IoTAuthenticationMethod",
         "PublicIoTAuthenticationMethod",

--- a/tests/test_session_stubbed.py
+++ b/tests/test_session_stubbed.py
@@ -21,9 +21,10 @@ from boto3_refresh_session.utils import (
 )
 from boto3_refresh_session.utils.typing import Method
 
-IOT_AVAILABLE = importlib.util.find_spec("awscrt") is not None
-
-if IOT_AVAILABLE:
+if IOT_AVAILABLE := (
+    importlib.util.find_spec("awscrt") is not None
+    and importlib.util.find_spec("awsiot") is not None
+):
     from boto3_refresh_session.methods.iot.x509 import (
         IOTX509RefreshableSession,
     )


### PR DESCRIPTION
## All submissions

* [x] Did you include the version part parameter, i.e. [major | minor | patch], to the beginning of the pull request title so that the version is bumped correctly? 
    * Example pull request title: '[minor] Added a new parameter to the `RefreshableSession` object.'
    * Note: the version part parameter is only required for major and minor updates. Patches may exclude the part parameter from the pull request title, as the default is 'patch'.
* [x] Did you verify that your changes pass pre-commit checks before opening this pull request?
    * The pre-commit checks are identical to required status checks for pull requests in this repository. Know that suppressing pre-commit checks via the `--no-verify` | `-nv` arguments will not help you avoid the status checks!
    * To ensure that pre-commit checks work on your branch before running `git commit`, run `pre-commit install` and `pre-commit install-hooks` beforehand. 
* [x] Have you checked that your changes don't relate to other open pull requests?

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

## New feature submissions

* [ ] Does your new feature include documentation? If not, why not?
    * [ ] Does that documentation match the numpydoc guidelines?
    * [x] Did you locally test your documentation changes using `sphinx-build doc doc/_build` from the root directory?
* [ ] Did you write unit tests for the new feature? If not, why not?
    * [ ] Did the unit tests pass?
    * [ ] Did you know that locally running unit tests requires an AWS account? 
        * You must create a ROLE_ARN environment variable on your machine using `export ROLE_ARN=<your role arn here>`.

## Submission details

The following PR adds `awsiot` in addition to `awscrt` when inferring whether `[iot]` extra was added during installation; this adds an extra layer of safety in case users happen to have `awscrt` installed.