### PR TITLE
[patch] Significant typing hint and alias upgrades + enhanced error handling.

### DIFF
--- a/boto3_refresh_session/methods/iot/core.py
+++ b/boto3_refresh_session/methods/iot/core.py
@@ -8,7 +8,7 @@ from __future__ import annotations
 
 __all__ = ["IoTRefreshableSession"]
 
-from typing import get_args
+from typing import TYPE_CHECKING, Literal, get_args, overload
 
 from ...exceptions import BRSValidationError
 from ...utils import (
@@ -17,8 +17,26 @@ from ...utils import (
     PublicIoTAuthenticationMethod,
 )
 
+if TYPE_CHECKING:
+    from .x509 import IOTX509RefreshableSession
 
-class IoTRefreshableSession(BaseRefreshableSession, registry_key="iot"):
+
+class IoTRefreshableSession(BaseRefreshableSession, registry_key="iot"):  # type: ignore[misc]
+    # overloading __new__ to return correct subclass per authentication_method
+    @overload
+    def __new__(
+        cls,
+        authentication_method: Literal["x509"] = "x509",
+        **kwargs,
+    ) -> "IOTX509RefreshableSession": ...
+
+    @overload
+    def __new__(  # type: ignore[reportIncompatibleMethodOverride]
+        cls,
+        authentication_method: PublicIoTAuthenticationMethod = "x509",
+        **kwargs,
+    ) -> BaseIoTRefreshableSession: ...
+
     def __new__(
         cls,
         authentication_method: PublicIoTAuthenticationMethod = "x509",
@@ -33,7 +51,7 @@ class IoTRefreshableSession(BaseRefreshableSession, registry_key="iot"):
                 f"{', '.join(repr(meth) for meth in methods)}.",
                 param="authentication_method",
                 value=authentication_method,
-            )
+            ) from None
 
         return BaseIoTRefreshableSession.registry[authentication_method](
             **kwargs

--- a/boto3_refresh_session/utils/cache.py
+++ b/boto3_refresh_session/utils/cache.py
@@ -7,6 +7,7 @@
 __all__ = ["ClientCache", "ClientCacheKey"]
 
 from collections import OrderedDict
+from collections.abc import Iterator
 from threading import RLock
 from typing import Any
 
@@ -255,7 +256,7 @@ class ClientCache:
         with self._lock:
             return key in self._cache
 
-    def __iter__(self):
+    def __iter__(self) -> Iterator[ClientCacheKey]:
         with self._lock:
             return iter(tuple(self._cache.keys()))
 
@@ -268,15 +269,19 @@ class ClientCache:
             else:
                 raise BRSCacheNotFoundError(
                     "The client you requested has not been cached."
-                )
+                ) from None
 
     def __setitem__(self, key: ClientCacheKey, obj: BaseClient) -> None:
         if not isinstance(key, ClientCacheKey):
-            raise BRSCacheError("Cache key must be of type 'ClientCacheKey'.")
+            raise BRSCacheError(
+                "Cache key must be of type 'ClientCacheKey'."
+            ) from None
 
         with self._lock:
             if key in self._cache:
-                raise BRSCacheExistsError("Client already exists in cache.")
+                raise BRSCacheExistsError(
+                    "Client already exists in cache."
+                ) from None
 
             # setting the object
             self._cache[key] = obj
@@ -290,7 +295,9 @@ class ClientCache:
     def __delitem__(self, key: ClientCacheKey) -> None:
         with self._lock:
             if key not in self._cache:
-                raise BRSCacheNotFoundError("Client not found in cache.")
+                raise BRSCacheNotFoundError(
+                    "Client not found in cache."
+                ) from None
             del self._cache[key]
 
     def keys(self) -> tuple[ClientCacheKey, ...]:
@@ -354,7 +361,9 @@ class ClientCache:
 
         with self._lock:
             if (obj := self._cache.get(key)) is None:
-                raise BRSCacheNotFoundError("Client not found in cache.")
+                raise BRSCacheNotFoundError(
+                    "Client not found in cache."
+                ) from None
             del self._cache[key]
             return obj
 

--- a/boto3_refresh_session/utils/config.py
+++ b/boto3_refresh_session/utils/config.py
@@ -160,7 +160,7 @@ class AssumeRoleConfig(BaseConfig):
         if key not in ASSUME_ROLE_CONFIG_PARAMETERS:
             raise BRSValidationError(
                 f"'{key}' is not a valid attribute for AssumeRoleConfig."
-            )
+            ) from None
 
         # ensuring TokenCode is a 6-digit numeric string
         if (
@@ -170,7 +170,7 @@ class AssumeRoleConfig(BaseConfig):
         ):
             raise BRSValidationError(
                 f"'{key}' must be a 6-digit numeric string."
-            )
+            ) from None
 
 
 class STSClientConfig(BaseConfig):
@@ -258,15 +258,19 @@ class STSClientConfig(BaseConfig):
                     )
                     value = "sts"
             else:
-                raise BRSValidationError("'service_name' must be a string.")
+                raise BRSValidationError(
+                    "'service_name' must be a string."
+                ) from None
 
         super().__setitem__(key, value)
 
     def _validate(self, key: str, value: Any) -> None:
         if not isinstance(key, str):
-            raise BRSValidationError("Attribute name must be a string.")
+            raise BRSValidationError(
+                "Attribute name must be a string."
+            ) from None
 
         if key not in STS_CLIENT_CONFIG_PARAMETERS:
             raise BRSValidationError(
                 f"'{key}' is not a valid attribute for STSClientConfig."
-            )
+            ) from None

--- a/docs/changelog.rst
+++ b/docs/changelog.rst
@@ -68,6 +68,7 @@ Refer to the `PR <https://github.com/michaelthomasletts/boto3-refresh-session/pu
 
 v7.1.12
 -------
+
 LRU caching has been added to ``ClientCache`` which previously did not have an eviction strategy. 
 To disable client caching altogether, set ``cache_clients=False`` when initializing ``RefreshableSession`` (it's set to True by default).
 To adjust the default maximum size of the client cache (which is 10), set the ``client_cache_max_size`` parameter when initializing ``RefreshableSession``.
@@ -84,8 +85,14 @@ This change was made to reduce the number of dependencies for users who do not r
 
 v7.2.12
 -------
+
 ``mfa_token_provider`` now supports CLI commands as a way to retrieve MFA tokens, in addition to callables. 
 A ``whoami()`` method was also added to ``RefreshableSession`` to retrieve the AWS identity of the current session as an alternative to ``get_identity()``.
 
 The first feature allows users to specify a command (as a string or list of strings) that will be executed to obtain the MFA token.
 The command is run using :py:func:`subprocess.run`, and any keyword arguments provided via ``mfa_token_provider_kwargs`` are forwarded to :py:func:`subprocess.run`.
+
+v7.2.13
+-------
+
+Typing hints and aliases significantly improved to enhance code clarity and developer experience.


### PR DESCRIPTION
## All submissions

* [x] Did you include the version part parameter (i.e. [major | minor | patch]) to the beginning of the pull request title so that the version is bumped correctly? 
    * Example pull request title: '[minor] Added a new parameter to the `RefreshableSession` object.'
    * Note: the version part parameter is only required for major and minor updates. Patches may exclude the part parameter from the pull request title, as the default is 'patch'.
* [x] Did you verify that your changes pass pre-commit checks before opening this pull request?
    * The pre-commit checks are identical to required status checks for pull requests in this repository. Know that suppressing pre-commit checks via the `--no-verify` | `-nv` arguments will not help you avoid the PR status checks!
    * To ensure that pre-commit checks work on your branch before running `git commit`, run `pre-commit install` and `pre-commit install-hooks` beforehand. 
    * `uv lock --check`, which is run by `pre-commit`, is the most critical pre-commit check of all for CI consistency.
* [x] Have you checked that your changes don't relate to other open pull requests?

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

## New feature submissions

* [ ] Does your new feature include documentation? If not, why not?
    * [ ] Does that documentation match the numpydoc guidelines?
    * [x] Did you locally test your documentation changes using `uv run bash -lc "cd docs && make html"` from the root directory?
* [x] Did you write unit tests for the new feature? If not, why not?
    * [x] Did the unit tests pass?

## Submission details

The following PR leverages `typing.TYPE_CHECKING` in order to allow the `iot` extras to be available from IDE's. For posterity, `TYPE_CHECKING` evaluates to `False` during runtime. Additionally, this PR declares `from None` so that manual error raising does not yield verbose (and unhelpful) tracebacks.