### PR TITLE
[patch] IOT_EXTRAS_INSTALLLED enforcement

### DIFF
--- a/boto3_refresh_session/__init__.py
+++ b/boto3_refresh_session/__init__.py
@@ -8,30 +8,25 @@ in a boto3.session.Session object automatically.
 
 __all__ = []
 
-import importlib.util
-
 from . import exceptions, session
 from .exceptions import *
-from .methods.custom import *
-from .methods.sts import *
+from .methods import *
 from .session import *
-from .utils import cache, config, typing
+from .utils import cache, config, extras, typing
 from .utils.cache import *
 from .utils.config import *
+from .utils.extras import *
 from .utils.typing import *
 
-# checking if iot extra is installed or not
-if (
-    importlib.util.find_spec("awscrt") is not None
-    and importlib.util.find_spec("awsiot") is not None
-):
-    from .methods.iot import *
-
+# controlling star imports
 __all__ += cache.__all__
 __all__ += config.__all__
 __all__ += session.__all__
 __all__ += exceptions.__all__
 __all__ += typing.__all__
+__all__ += extras.__all__
+
+# package metadata
 __version__ = "7.3.2"
 __title__ = "boto3-refresh-session"
 __author__ = "Mike Letts"

--- a/boto3_refresh_session/methods/__init__.py
+++ b/boto3_refresh_session/methods/__init__.py
@@ -4,8 +4,7 @@
 
 __all__ = []
 
-import importlib.util
-
+from ..utils import IOT_EXTRA_INSTALLED
 from . import custom, sts
 from .custom import *
 from .sts import *
@@ -14,10 +13,7 @@ __all__ += custom.__all__
 __all__ += sts.__all__
 
 # checking if iot extra is installed
-if (
-    importlib.util.find_spec("awscrt") is not None
-    and importlib.util.find_spec("awsiot") is not None
-):
+if IOT_EXTRA_INSTALLED:
     from . import iot
     from .iot import *
 

--- a/boto3_refresh_session/methods/iot/__init__.py
+++ b/boto3_refresh_session/methods/iot/__init__.py
@@ -7,13 +7,10 @@ installation of the 'iot' extra."""
 
 __all__ = []
 
-import importlib.util
+from ...utils import IOT_EXTRA_INSTALLED
 
 # checking if iot extra is installed
-if (
-    importlib.util.find_spec("awscrt") is not None
-    and importlib.util.find_spec("awsiot") is not None
-):
+if IOT_EXTRA_INSTALLED:
     from . import x509
     from .x509 import IOTX509RefreshableSession
 

--- a/boto3_refresh_session/session.py
+++ b/boto3_refresh_session/session.py
@@ -13,11 +13,10 @@ from typing import List, TypeAlias, get_args
 from .exceptions import BRSValidationError
 from .methods.custom import CustomRefreshableSession
 from .methods.sts import STSRefreshableSession
-from .utils import Method, Registry
-from .utils.typing import _IOT_EXTRA_INSTALLED
+from .utils import IOT_EXTRA_INSTALLED, Method, Registry
 
 # defining this here instead of utils.typing to avoid circular imports
-if not _IOT_EXTRA_INSTALLED:
+if not IOT_EXTRA_INSTALLED:
     RefreshableSessionType: TypeAlias = (  # type: ignore
         STSRefreshableSession | CustomRefreshableSession  # type: ignore
     )

--- a/boto3_refresh_session/utils/__init__.py
+++ b/boto3_refresh_session/utils/__init__.py
@@ -4,15 +4,17 @@
 
 __all__ = []
 
-from . import cache, config, constants, internal, typing
+from . import cache, config, constants, extras, internal, typing
 from .cache import *
 from .config import *
 from .constants import *
+from .extras import *
 from .internal import *
 from .typing import *
 
 __all__ += cache.__all__
 __all__ += config.__all__
 __all__ += constants.__all__
+__all__ += extras.__all__
 __all__ += internal.__all__
 __all__ += typing.__all__

--- a/boto3_refresh_session/utils/constants.py
+++ b/boto3_refresh_session/utils/constants.py
@@ -10,14 +10,19 @@ __all__ = [
 
 import inspect
 import subprocess
+from typing import Set, Tuple
 
 from .typing import AssumeRoleParams, STSClientParams
 
 # config parameter names
-ASSUME_ROLE_CONFIG_PARAMETERS = tuple(AssumeRoleParams.__annotations__)
-STS_CLIENT_CONFIG_PARAMETERS = tuple(STSClientParams.__annotations__)
+ASSUME_ROLE_CONFIG_PARAMETERS: Tuple[str, ...] = tuple(
+    AssumeRoleParams.__annotations__
+)
+STS_CLIENT_CONFIG_PARAMETERS: Tuple[str, ...] = tuple(
+    STSClientParams.__annotations__
+)
 
 # subprocess.run parameter names
-SUBPROCESS_ALLOWED_PARAMETERS = set(
+SUBPROCESS_ALLOWED_PARAMETERS: Set[str] = set(
     inspect.signature(subprocess.run).parameters
 ) | set(inspect.signature(subprocess.Popen).parameters)

--- a/boto3_refresh_session/utils/extras.py
+++ b/boto3_refresh_session/utils/extras.py
@@ -1,0 +1,17 @@
+# This Source Code Form is subject to the terms of the Mozilla Public
+# License, v. 2.0. If a copy of the MPL was not distributed with this
+# file, You can obtain one at https://mozilla.org/MPL/2.0/.
+
+"""Utilities for checking the presence of optional dependencies (extras)."""
+
+__all__ = ["IOT_EXTRA_INSTALLED"]
+
+from importlib.util import find_spec
+from typing import TYPE_CHECKING
+
+# checking whether 'iot' extra is installed or we're in a type-checking context
+IOT_EXTRA_INSTALLED: bool = (
+    True
+    if TYPE_CHECKING
+    else find_spec("awscrt") is not None and find_spec("awsiot") is not None
+)

--- a/boto3_refresh_session/utils/typing.py
+++ b/boto3_refresh_session/utils/typing.py
@@ -16,9 +16,7 @@ __all__ = [
     "TemporaryCredentials",
 ]
 
-import importlib.util
 from typing import (
-    TYPE_CHECKING,
     Any,
     List,
     Literal,
@@ -27,31 +25,18 @@ from typing import (
     TypeVar,
 )
 
+from botocore.config import Config
+
+from .extras import IOT_EXTRA_INSTALLED
+
 try:
     from typing import NotRequired  # type: ignore[import]
 except ImportError:
     from typing_extensions import NotRequired
 
-from botocore.config import Config
-
-
-def _iot_extra_installed() -> bool:
-    """Determines whether the 'iot' extra is installed.
-
-    Returns
-    -------
-    bool
-        ``True`` if the 'iot' extra is installed, ``False`` otherwise.
-    """
-
-    return (
-        importlib.util.find_spec("awscrt") is not None
-        and importlib.util.find_spec("awsiot") is not None
-    )
-
 
 # checking whether 'iot' extra is installed or we're in a type-checking context
-if _IOT_EXTRA_INSTALLED := True if TYPE_CHECKING else _iot_extra_installed():
+if IOT_EXTRA_INSTALLED:
     __all__ += ["PKCS11", "Transport"]
 
     #: Type alias for all currently available credential refresh methods.
@@ -64,6 +49,29 @@ if _IOT_EXTRA_INSTALLED := True if TYPE_CHECKING else _iot_extra_installed():
 
     #: Type alias for acceptable transports
     Transport: TypeAlias = Literal["x509", "ws"]
+
+    class PKCS11(TypedDict):
+        """Configuration for PKCS#11 library.
+
+        Attributes
+        ----------
+        pkcs11_lib : str
+            The path to the PKCS#11 library.
+        user_pin : str or None, optional
+            The user PIN for the PKCS#11 token.
+        slot_id : int or None, optional
+            The slot ID of the PKCS#11 token.
+        token_label : str or None, optional
+            The label of the PKCS#11 token.
+        private_key_label : str or None, optional
+            The label of the private key on the PKCS#11 token.
+        """
+
+        pkcs11_lib: str
+        user_pin: NotRequired[str | None]
+        slot_id: NotRequired[int | None]
+        token_label: NotRequired[str | None]
+        private_key_label: NotRequired[str | None]
 else:
     #: Type alias for currently available credential refresh methods.
     Method: TypeAlias = Literal["custom", "sts"]  # type: ignore
@@ -259,29 +267,3 @@ class STSClientParams(TypedDict):
     aws_session_token: NotRequired[str]
     config: NotRequired[Config]
     aws_account_id: NotRequired[str]
-
-
-if _IOT_EXTRA_INSTALLED:
-
-    class PKCS11(TypedDict):
-        """Configuration for PKCS#11 library.
-
-        Attributes
-        ----------
-        pkcs11_lib : str
-            The path to the PKCS#11 library.
-        user_pin : str or None, optional
-            The user PIN for the PKCS#11 token.
-        slot_id : int or None, optional
-            The slot ID of the PKCS#11 token.
-        token_label : str or None, optional
-            The label of the PKCS#11 token.
-        private_key_label : str or None, optional
-            The label of the private key on the PKCS#11 token.
-        """
-
-        pkcs11_lib: str
-        user_pin: NotRequired[str | None]
-        slot_id: NotRequired[int | None]
-        token_label: NotRequired[str | None]
-        private_key_label: NotRequired[str | None]

--- a/tests/test_cache.py
+++ b/tests/test_cache.py
@@ -4,7 +4,7 @@
 
 from botocore.config import Config
 
-from boto3_refresh_session.utils.cache import ClientCache, ClientCacheKey
+from boto3_refresh_session import ClientCache, ClientCacheKey
 
 
 def test_client_cache_key_normalizes_config() -> None:

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -1,7 +1,11 @@
 import pytest
 
-from boto3_refresh_session.exceptions import BRSValidationError, BRSWarning
-from boto3_refresh_session.utils import AssumeRoleConfig, STSClientConfig
+from boto3_refresh_session import (
+    AssumeRoleConfig,
+    BRSValidationError,
+    BRSWarning,
+    STSClientConfig,
+)
 
 
 def test_assume_role_config_behaves_like_dict():

--- a/tests/test_mfa_token_provider.py
+++ b/tests/test_mfa_token_provider.py
@@ -4,12 +4,12 @@ from typing import cast
 import pytest
 
 import boto3_refresh_session.methods.sts as sts_module
-from boto3_refresh_session.exceptions import (
+from boto3_refresh_session import (
+    AssumeRoleConfig,
     BRSConfigurationError,
     BRSValidationError,
+    STSRefreshableSession,
 )
-from boto3_refresh_session.methods.sts import STSRefreshableSession
-from boto3_refresh_session.utils import AssumeRoleConfig
 
 
 def _session():


### PR DESCRIPTION
## All submissions

* [x] Did you include the version part parameter (i.e. [major | minor | patch]) to the beginning of the pull request title so that the version is bumped correctly? 
    * Example pull request title: '[minor] Added a new parameter to the `RefreshableSession` object.'
    * Note: the version part parameter is only required for major and minor updates. Patches may exclude the part parameter from the pull request title, as the default is 'patch'.
* [x] Did you verify that your changes pass pre-commit checks before opening this pull request?
    * The pre-commit checks are identical to required status checks for pull requests in this repository. Know that suppressing pre-commit checks via the `--no-verify` | `-nv` arguments will not help you avoid the PR status checks!
    * To ensure that pre-commit checks work on your branch before running `git commit`, run `pre-commit install` and `pre-commit install-hooks` beforehand. 
    * `uv lock --check`, which is run by `pre-commit`, is the most critical pre-commit check of all for CI consistency.
* [x] Have you checked that your changes don't relate to other open pull requests?

## New feature submissions

* [ ] Did you write unit tests for the new feature? If not, why not?
    * [x] Did the unit tests pass?

## Submission details

The following PR renames the private `_IOT_EXTRA_INSTALLED` constant to a public `IOT_EXTRA_INSTALLED` constant and places it into `utils.extras.py`. This constant infers whether users are in a type-checking context or have the `"iot"` extra installed. Previously, that evaluation occurred in multiple places across the repository with inconsistency, which was sloppy and redundant.